### PR TITLE
Add a header with update date in the CNA view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -210,6 +210,7 @@ function App() {
 
 				     <CNAContainer
 					 cna = {data.containers.cna}
+           header = {true}
 				     />
 				     
 				 </Tab.Pane>

--- a/src/CNAContainer.js
+++ b/src/CNAContainer.js
@@ -1,15 +1,18 @@
 import React from 'react';
+import { format } from 'date-fns';
 import {Badge} from 'react-bootstrap';
 import CVSSSeverityBadge from './CVSSSeverityBadge.js';
 
-const CNAContainer = ({cna}) => {
+const CNAContainer = ({cna, header}) => {
 
 
 
 
     return (
 	<div className="cna-container">
-
+      {header && (
+      <p className="lead fw-bold">The CNA last updated this entry on {format(new Date(cna.providerMetadata?.dateUpdated), 'yyyy-MM-dd')}.</p>
+      )}
 	    {cna.descriptions?.length > 0 && (
 	    <div className="mb-3"><b>Description:</b><br/>
 		{cna.descriptions.map((d, index) => (


### PR DESCRIPTION
We displayed the overall record publish and update timestamps in the header material, and ADP update timestamp in the ADP container view, but did not show the CNA update timestamp. Added to the CNA view, and set a switch that will trigger its display.